### PR TITLE
Use build profile to enable RTEMS cross build

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+epics-sscan (2.10-2) unstable; urgency=medium
+
+  * Use build profile to enable RTEMS cross build
+
+ -- Martin Konrad <konrad@frib.msu.edu>  Fri, 14 Sep 2018 13:16:59 -0400
+
 epics-sscan (2.10-1) unstable; urgency=medium
 
   * initial

--- a/debian/control
+++ b/debian/control
@@ -2,17 +2,17 @@ Source: epics-sscan
 Section: libdevel
 Priority: extra
 Maintainer: Michael Davidsaver <mdavidsaver@gmail.com>
-Build-Depends: debhelper (>= 9), epics-debhelper (>= 8.14~),
-               epics-dev,
-               rtems-epics-mvme2100,
-               rtems-epics-mvme3100,
-               rtems-epics-mvme5500,
-               rtems-epics-pc386,
+Build-Depends: debhelper (>= 9.20141010), dpkg-dev (>= 1.17.14),
+               epics-debhelper (>= 8.14~), epics-dev,
+               rtems-epics-mvme2100 <pkg.epics-base.rtems>,
+               rtems-epics-mvme3100 <pkg.epics-base.rtems>,
+               rtems-epics-mvme5500 <pkg.epics-base.rtems>,
+               rtems-epics-pc386 <pkg.epics-base.rtems>,
                epics-seq-dev,
-               rtems-seq-mvme2100,
-               rtems-seq-mvme3100,
-               rtems-seq-mvme5500,
-               rtems-seq-pc386,
+               rtems-seq-mvme2100 <pkg.epics-base.rtems>,
+               rtems-seq-mvme3100 <pkg.epics-base.rtems>,
+               rtems-seq-mvme5500 <pkg.epics-base.rtems>,
+               rtems-seq-pc386 <pkg.epics-base.rtems>,
 XS-Rtems-Build-Depends: rtems-epics, rtems-seq,
 Standards-Version: 3.9.6
 Homepage: http://aps.anl.gov/bcda/synApps/sscan/sscan.html
@@ -41,6 +41,7 @@ Description: Parametric scanning module
  This package contains runtime libraries
 
 Package: rtems-sscan-mvme2100
+Build-Profiles: <pkg.epics-base.rtems>
 Architecture: all
 Depends: epics-sscan-dev (>= ${source:Version}),
          epics-sscan-dev (<< ${source:Version}.1~),
@@ -53,6 +54,7 @@ Description: Parametric scanning module
  This package contains support for the MVME2100 VME SBC
 
 Package: rtems-sscan-mvme3100
+Build-Profiles: <pkg.epics-base.rtems>
 Architecture: all
 Depends: epics-sscan-dev (>= ${source:Version}),
          epics-sscan-dev (<< ${source:Version}.1~),
@@ -65,6 +67,7 @@ Description: Parametric scanning module
  This package contains support for the MVME3100 VME SBC
 
 Package: rtems-sscan-mvme5500
+Build-Profiles: <pkg.epics-base.rtems>
 Architecture: all
 Depends: epics-sscan-dev (>= ${source:Version}),
          epics-sscan-dev (<< ${source:Version}.1~),
@@ -77,6 +80,7 @@ Description: Parametric scanning module
  This package contains support for the MVME5500 VME SBC
 
 Package: rtems-sscan-pc386
+Build-Profiles: <pkg.epics-base.rtems>
 Architecture: all
 Depends: epics-sscan-dev (>= ${source:Version}),
          epics-sscan-dev (<< ${source:Version}.1~),

--- a/debian/source/lintian-overrides
+++ b/debian/source/lintian-overrides
@@ -1,0 +1,12 @@
+epics-sscan source: invalid-restriction-formula-in-build-profiles-field <pkg.epics-base.rtems> rtems-sscan-mvme2100
+epics-sscan source: invalid-restriction-formula-in-build-profiles-field <pkg.epics-base.rtems> rtems-sscan-mvme3100
+epics-sscan source: invalid-restriction-formula-in-build-profiles-field <pkg.epics-base.rtems> rtems-sscan-mvme5500
+epics-sscan source: invalid-restriction-formula-in-build-profiles-field <pkg.epics-base.rtems> rtems-sscan-pc386
+epics-sscan source: invalid-profile-name-in-source-relation pkg.epics-base.rtems [build-depends: rtems-epics-mvme2100 <pkg.epics-base.rtems>]
+epics-sscan source: invalid-profile-name-in-source-relation pkg.epics-base.rtems [build-depends: rtems-epics-mvme3100 <pkg.epics-base.rtems>]
+epics-sscan source: invalid-profile-name-in-source-relation pkg.epics-base.rtems [build-depends: rtems-epics-mvme5500 <pkg.epics-base.rtems>]
+epics-sscan source: invalid-profile-name-in-source-relation pkg.epics-base.rtems [build-depends: rtems-epics-pc386 <pkg.epics-base.rtems>]
+epics-sscan source: invalid-profile-name-in-source-relation pkg.epics-base.rtems [build-depends: rtems-seq-mvme2100 <pkg.epics-base.rtems>]
+epics-sscan source: invalid-profile-name-in-source-relation pkg.epics-base.rtems [build-depends: rtems-seq-mvme3100 <pkg.epics-base.rtems>]
+epics-sscan source: invalid-profile-name-in-source-relation pkg.epics-base.rtems [build-depends: rtems-seq-mvme5500 <pkg.epics-base.rtems>]
+epics-sscan source: invalid-profile-name-in-source-relation pkg.epics-base.rtems [build-depends: rtems-seq-pc386 <pkg.epics-base.rtems>]


### PR DESCRIPTION
This allows facilities that do not use RTEMS to get rid of the complexity of building this package's RTEMS dependencies. Set the environment variable `DEB_BUILD_PROFILES=pkg.epics-base.rtems` when compiling to enable the RTEMS build.